### PR TITLE
Fix (JTH-00) : 로그인 로직 및 토큰 전달 방식, 스웨거 설정 수정

### DIFF
--- a/src/main/java/com/example/musing/auth/JWT/DTO/Oauth2Google.java
+++ b/src/main/java/com/example/musing/auth/JWT/DTO/Oauth2Google.java
@@ -22,6 +22,7 @@ public record Oauth2Google (
                 .name((String) attributes.get("name"))
                 .email((String) attributes.get("email"))
                 .profile((String) attributes.get("picture")).build();
+
         //이름,이메일,프로필 이미지 링크
     }
 

--- a/src/main/java/com/example/musing/auth/JWT/TokenProvider.java
+++ b/src/main/java/com/example/musing/auth/JWT/TokenProvider.java
@@ -5,6 +5,7 @@ import com.example.musing.auth.exception.TokenException;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.Cookie;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -38,15 +39,30 @@ public class TokenProvider {
     private void setSecretKey() {
         secretKey = Keys.hmacShaKeyFor(key.getBytes());
     }
+
+    //쿠키 생성
+    public Cookie generateCookie(String accessToken){
+        String cookieName = "accessToken";
+        String cookieValue = accessToken;
+        Cookie cookie = new Cookie(cookieName,cookieValue);
+
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setPath("/");
+        cookie.setMaxAge(60*30);
+
+        return cookie;
+    }
+
     //엑세스 토큰 생성
     public String generateAccessToken(Authentication authentication) {
         return generateToken(authentication, ACCESS_TOKEN_EXPIRE_TIME);
     }
 
     //리프래쉬 토큰 생성 및 수정
-    public void generateRefreshToken(Authentication authentication, String accessToken) {
+    public void generateRefreshToken(Token token, Authentication authentication, String accessToken) {
         String refreshToken = generateToken(authentication, REFRESH_TOKEN_EXPIRE_TIME);
-        tokenService.saveOrUpdate(authentication.getName(),accessToken, refreshToken); //토큰 db에 저장하려는 부분 수정하기
+        tokenService.saveOrUpdate(token, authentication.getName(),accessToken, refreshToken); //토큰 db에 저장하려는 부분 수정하기
     }
     private String generateToken(Authentication authentication, long expireTime) {
         Date now = new Date();

--- a/src/main/java/com/example/musing/auth/JWT/TokenService.java
+++ b/src/main/java/com/example/musing/auth/JWT/TokenService.java
@@ -15,15 +15,14 @@ public class TokenService {
     private final TokenRepository tokenRepository;
 
     @Transactional
-    public void saveOrUpdate(String memberKey, String accessToken, String refreshToken) {
-        Optional<Token> token = tokenRepository.findById(memberKey);
-        if(token.isPresent()){
-            token.get().updateAccessToken(accessToken);
-            token.get().updateRefreshToken(refreshToken); //새로만들어서 저장하지만 생성기간과 유효기간만 바뀜
+    public void saveOrUpdate(Token token, String memberKey, String accessToken, String refreshToken) {
+        if(token!=null){
+            token.updateAccessToken(accessToken);
+            token.updateRefreshToken(refreshToken); //새로만들어서 저장하지만 생성기간과 유효기간만 바뀜
         }else{//해당 유저 아이디의 리프래시 토큰이 없으면 새로생성
-             token = Optional.of(new Token(memberKey, accessToken, refreshToken));
+             token = new Token(memberKey, accessToken, refreshToken);
         }
-        tokenRepository.save(token.get());
+        tokenRepository.save(token);
     }
     public Token issueAccessToken(String accessToken){
         return tokenRepository.findByAccesstoken(accessToken).orElseThrow(() -> new TokenException(TOKEN_EXPIRED));

--- a/src/main/java/com/example/musing/auth/MainController.java
+++ b/src/main/java/com/example/musing/auth/MainController.java
@@ -19,6 +19,7 @@ import java.util.Objects;
 @Tag(name = "메인 페이지 관련 도메인", description = "메인 페이지 및 모달 창")
 public class MainController {
     //http://localhost:8090/oauth2/authorization/google //구글 로그인
+    //http://localhost:8090/swagger-ui/index.html //스웨거
     private final UserService userService;
     @Operation(summary = "로그인 테스트용" ,
             description = "localhost:8090 기준 http://localhost:8090/oauth2/authorization/google 로 접근<br>" +

--- a/src/main/java/com/example/musing/auth/filter/TokenAuthenticationFilter.java
+++ b/src/main/java/com/example/musing/auth/filter/TokenAuthenticationFilter.java
@@ -6,6 +6,7 @@ import com.example.musing.auth.JWT.TokenService;
 import com.example.musing.auth.exception.TokenException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +18,7 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import static com.example.musing.exception.ErrorCode.TOKEN_EXPIRED;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
@@ -42,17 +44,27 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
                 // 만료되었을 경우 accessToken 재발급
                 //reissueAccessToken에 리프래시토큰 만료상태 확인 로직있음
                 String reissueAccessToken = tokenProvider.reissueAccessToken(accessToken);
-                logger.info(reissueAccessToken);
+                logger.info("토큰값" + reissueAccessToken);
                 if (StringUtils.hasText(reissueAccessToken)) {//재발급이 성공했다면
                     setAuthentication(reissueAccessToken);//시큐리티 콘텍스트 추가
 
                     // 재발급된 accessToken 다시 전달
-                    response.setHeader(AUTHORIZATION, "Bearer " + reissueAccessToken);
+                    /*response.setHeader(AUTHORIZATION, "Bearer " + reissueAccessToken);*/
+
+                    //기존 쿠키 남은거 있나확인하고 없애고 새로 넣어주기
+                    //Null이 아니면 쿠키 삭제하기
+                    Objects.requireNonNull(checkCookie(request)).setMaxAge(0);
+                    //새로 발급한 엑세스 토큰 쿠키로 반환
+                    tokenProvider.generateCookie(reissueAccessToken);
+
                 }else{
                     //리프래시토큰 만료되었을 경우
                     //레디스 적용할 경우 만료 시 삭제처리 할거기때문에 지울수 있는 부분
                     tokenService.deleteRefreshToken(accessToken);
                     response.setHeader(AUTHORIZATION,null);//만료된 토큰이 헤더에 있을경우 대비
+                    //쿠키 삭제
+                    Objects.requireNonNull(checkCookie(request)).setMaxAge(0);
+
                     throw new TokenException(TOKEN_EXPIRED);//만료되었다는 예외처리
                     //리프래시 토큰을 삭제해야 필터에 걸리지않고 로그인 다시하면 발급이 가능해짐
                 }
@@ -60,6 +72,14 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
         }
         //리프래시 토큰이 만료되었거나 값이 없으면 통과
         filterChain.doFilter(request, response);
+    }
+    private Cookie checkCookie(HttpServletRequest request){
+        for(Cookie cookie : request.getCookies()){
+            if(cookie.getName().equals("accessToken")){
+                return cookie;
+            }
+        }
+        return null;
     }
 
     private void setAuthentication(String accessToken) {
@@ -70,10 +90,17 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
     }
 
     private String resolveToken(HttpServletRequest request) {
-        String token = request.getHeader(AUTHORIZATION);
-        if (ObjectUtils.isEmpty(token) || !token.startsWith("Bearer ")) {
+/*        String token = request.getHeader(AUTHORIZATION);*/
+        String token = null;
+        for(Cookie cookie : request.getCookies()){
+            if(cookie.getName().equals("accessToken")){
+                 token = cookie.getValue();
+            }
+        }
+
+        if (ObjectUtils.isEmpty(token)) {
             return null;
         }
-        return token.substring("Bearer ".length());
+        return token;
     }
 }

--- a/src/main/java/com/example/musing/config/SwaggerConfig.java
+++ b/src/main/java/com/example/musing/config/SwaggerConfig.java
@@ -3,22 +3,36 @@ package com.example.musing.config;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class SwaggerConfig {
     @Bean
-    public OpenAPI openAPI() {
-        return new OpenAPI()
-                .components(new Components())
-                .info(apiInfo());
-    }
-
-    private Info apiInfo() {
-        return new Info()
+    public OpenAPI apiInfo() {
+        Info info = new Info()
                 .title("musing 스웨거 문서")
                 .description("최종 작성일자: 24.12.13")
                 .version("1.0.0");
+
+        // SecuritySecheme명
+        String jwtSchemeName = "accessToken";
+        // API 요청헤더에 인증정보 포함
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
+        // SecuritySchemes 등록
+        Components components = new Components()
+                .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
+                        .name(jwtSchemeName)
+                        .type(SecurityScheme.Type.HTTP) // HTTP 방식
+                        .scheme("bearer")
+                        .bearerFormat("JWT")); // 토큰 형식을 지정하는 임의의 문자(Optional)
+            return new OpenAPI()
+                    .components(new Components())
+                    .info(info)
+                    .addSecurityItem(securityRequirement)
+                    .components(components);
+
     }
 }

--- a/src/main/java/com/example/musing/like_music/entity/Like_Music.java
+++ b/src/main/java/com/example/musing/like_music/entity/Like_Music.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @Entity
-
+@Table(name="like_music")
 public class Like_Music {
 
    //유저가 좋아요를 눌렀을때에 관한 객체

--- a/src/main/java/com/example/musing/user/entity/User.java
+++ b/src/main/java/com/example/musing/user/entity/User.java
@@ -8,16 +8,19 @@ import com.example.musing.prefer.entity.Prefer;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 
 import java.util.ArrayList;
 import java.util.List;
 
-@Data // Lombok 어노테이션 : 클래스 내 모든 필드의 Getter 메소드 자동 생성
+@Getter // Lombok 어노테이션 : 클래스 내 모든 필드의 Getter 메소드 자동 생성
 @NoArgsConstructor // Lombok 어노테이션 : 기본 생성자 자동 추가
 @Entity
 @Table(name = "user")
+@DynamicInsert
 @DynamicUpdate  //update 될때 바뀐 컬럼만 변경하도록 함, 기존에는 모든 컬럼을 가져와서 바꿈
 public class User { //https://developers.google.com/identity/openid-connect/openid-connect?hl=ko#an-id-tokens-payload
     @Id
@@ -73,6 +76,10 @@ public class User { //https://developers.google.com/identity/openid-connect/open
         this.email=email;
         this.profile=profile;
         this.role = Role.USER;
+    }
+    public void updateGoogleInfo(String username, String profile){
+        this.username =username;
+        this.profile = profile;
     }
     public void updateGenre(String genre){
         this.likegenre = genre;


### PR DESCRIPTION
로그인 기존에는 Header로 전송하던 엑세스 토큰을 쿠키로 전달하는 방식으로 변경.
토큰 전달을 쿠키로 변경하면서 쿠키를 삭제하는 부분을 추가.
불필요한 DB조회하는 부분 제거.
스웨거 엑세스 토큰 값을 넣는 걸로 추가