### PR TITLE
음악 추천 게시글 관련 기능 수정

### DIFF
--- a/src/main/java/com/example/musing/admin/board/controller/AdminBoardController.java
+++ b/src/main/java/com/example/musing/admin/board/controller/AdminBoardController.java
@@ -13,14 +13,14 @@ import org.springframework.web.bind.annotation.*;
 public class AdminBoardController {
     private AdminBoardService adminBoardService;
 
-    @GetMapping("/list/removed/page")
+    @GetMapping("/list/removed")
     public ResponseDto<Page<AdminBoardResponseDto.BoardListDto>> getDeleteBoards(
             @RequestParam(name = "page", defaultValue = "1") int page) {
         Page<AdminBoardResponseDto.BoardListDto> responseList = adminBoardService.getDeletedPage(page);
         return ResponseDto.of(responseList);
     }
 
-    @GetMapping("/list/removed/page/search")
+    @GetMapping("/list/removed/search")
     public ResponseDto<Page<AdminBoardResponseDto.BoardListDto>> getDeleteBoardsByKeyword(
             @RequestParam(name = "page", defaultValue = "1") int page,
             @RequestParam(name = "searchType") String searchType,
@@ -30,14 +30,14 @@ public class AdminBoardController {
         return ResponseDto.of(responseList);
     }
 
-    @GetMapping("/list/page")
+    @GetMapping("/list")
     public ResponseDto<Page<AdminBoardResponseDto.BoardListDto>> getBoards(
             @RequestParam(name = "page", defaultValue = "1") int page) {
         Page<AdminBoardResponseDto.BoardListDto> responseList = adminBoardService.getRegisterPermitPage(page);
         return ResponseDto.of(responseList);
     }
 
-    @GetMapping("/list/page/search")
+    @GetMapping("/list/search")
     public ResponseDto<Page<AdminBoardResponseDto.BoardListDto>> getBoardsByKeyword(
             @RequestParam(name = "page", defaultValue = "1") int page,
             @RequestParam(name = "searchType") String searchType,

--- a/src/main/java/com/example/musing/board/controller/BoardController.java
+++ b/src/main/java/com/example/musing/board/controller/BoardController.java
@@ -60,11 +60,11 @@ public class BoardController {
     }
 
     @PutMapping(value ="/updatePost", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseDto<Board> updatePost(@ModelAttribute @Valid UpdateBoardRequestDto updateRequest,
+    public ResponseDto<Board> updatePost(@PathVariable long boardId, @ModelAttribute @Valid UpdateBoardRequestDto updateRequest,
                                          @RequestPart(required = false) List<String> deleteFileLinks,
                                          @RequestPart(required = false) List<MultipartFile> files) {
 
-        boardService.updateBoard(updateRequest, deleteFileLinks, files);
+        boardService.updateBoard(boardId, updateRequest, deleteFileLinks, files);
         return ResponseDto.of(null,"성공적으로 글이 수정되었습니다.");
     }
 

--- a/src/main/java/com/example/musing/board/controller/BoardController.java
+++ b/src/main/java/com/example/musing/board/controller/BoardController.java
@@ -61,11 +61,10 @@ public class BoardController {
 
     @PutMapping(value ="/updatePost", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseDto<Board> updatePost(@ModelAttribute @Valid UpdateBoardRequestDto updateRequest,
-                                         @RequestPart(value = "image", required = false) List<MultipartFile> images){
-        if(images == null || images.isEmpty()) {
-            images = new ArrayList<>();
-        }
-        boardService.updateBoard(updateRequest,images);
+                                         @RequestPart(required = false) List<String> deleteFileLinks,
+                                         @RequestPart(required = false) List<MultipartFile> files) {
+
+        boardService.updateBoard(updateRequest, deleteFileLinks, files);
         return ResponseDto.of(null,"성공적으로 글이 수정되었습니다.");
     }
 

--- a/src/main/java/com/example/musing/board/dto/BoardRequestDto.java
+++ b/src/main/java/com/example/musing/board/dto/BoardRequestDto.java
@@ -44,7 +44,7 @@ public class BoardRequestDto {
                     .replyCount(board.getReplyCount())
                     .thumbNailLink(board.getMusic().getThumbNailLink())
                     .content(board.getContent())
-                    .imageUrl(board.getImage())
+                    .imageUrl(board.getImages())
                     .genreList(genreList)
                     .moodList(moodList)
                     .build();

--- a/src/main/java/com/example/musing/board/dto/CreateBoardRequest.java
+++ b/src/main/java/com/example/musing/board/dto/CreateBoardRequest.java
@@ -12,10 +12,10 @@ public class CreateBoardRequest {
 
     private String title;
     private String musicTitle;
-    private String artist;
+    private List<String> artist;
     private String youtubeLink;
     private List<String> hashtags;
-    private Long genre;
+    private List<Long> genre;
     private String content;
     private String playtime;
     private String AlbumName;

--- a/src/main/java/com/example/musing/board/dto/DetailResponse.java
+++ b/src/main/java/com/example/musing/board/dto/DetailResponse.java
@@ -40,7 +40,7 @@ public record DetailResponse(
                 .playtime(board.getMusic().getPlaytime())
                 .AlbumName(board.getMusic().getAlbumName())
                 .songLink(board.getMusic().getSongLink())
-                .thumbNailLink(board.getImage())
+                .thumbNailLink(board.getMusic().getThumbNailLink())
                 .build();
     }
 }

--- a/src/main/java/com/example/musing/board/dto/DetailResponse.java
+++ b/src/main/java/com/example/musing/board/dto/DetailResponse.java
@@ -16,23 +16,26 @@ public record DetailResponse(
     String username,
     LocalDateTime createdAt,
     LocalDateTime updatedAt,
-    String artist,
+    List<String> artist,
     String youtubeLink,
     List<String> hashtags,
-    Long genre,
+    List<String> genre,
     String content,
     String playtime,
     String AlbumName,
     String songLink,
     String thumbNailLink) {
-    public static DetailResponse of(Board board, String artistsName, List<String> hashtags, Long genreIds) {
+    public static DetailResponse of(Board board, List<String> artistsName, List<String> hashtags, List<String> genreName) {
         return DetailResponse.builder()
                 .title(board.getTitle())
                 .musicTitle(board.getMusic().getName())
+                .username(board.getUser().getUsername())
+                .createdAt(board.getCreatedAt())
+                .updatedAt(board.getUpdatedAt())
                 .artist(artistsName)
                 .youtubeLink(board.getMusic().getSongLink())
                 .hashtags(hashtags) // 해시태그 추출
-                .genre(genreIds)
+                .genre(genreName)
                 .content(board.getContent())
                 .playtime(board.getMusic().getPlaytime())
                 .AlbumName(board.getMusic().getAlbumName())

--- a/src/main/java/com/example/musing/board/dto/PostDto.java
+++ b/src/main/java/com/example/musing/board/dto/PostDto.java
@@ -46,7 +46,7 @@ public class PostDto {
                 .viewCount(board.getViewCount())
                 .activeCheck(board.isActiveCheck())
                 .permitRegister(board.getPermitRegister())
-                .image(board.getImage())
+                .image(board.getImages())
                 .build();
     }
 

--- a/src/main/java/com/example/musing/board/dto/UpdateBoardRequestDto.java
+++ b/src/main/java/com/example/musing/board/dto/UpdateBoardRequestDto.java
@@ -16,10 +16,10 @@ public class UpdateBoardRequestDto {
     private Long boardId;
     private String title;
     private String musicTitle;
-    private String artist;
+    private List<String> artist;
     private String youtubeLink;
     private List<String> hashtags;
-    private Long genre;
+    private List<Long> genre;
     private String content;
     private String playtime;
     private String songLink;

--- a/src/main/java/com/example/musing/board/dto/UpdateBoardRequestDto.java
+++ b/src/main/java/com/example/musing/board/dto/UpdateBoardRequestDto.java
@@ -12,8 +12,6 @@ import java.util.List;
 @NoArgsConstructor
 public class UpdateBoardRequestDto {
 
-    //업데이트 리퀘스트 dto
-    private Long boardId;
     private String title;
     private String musicTitle;
     private List<String> artist;

--- a/src/main/java/com/example/musing/board/entity/Board.java
+++ b/src/main/java/com/example/musing/board/entity/Board.java
@@ -15,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static com.example.musing.board.entity.CheckRegister.NON_CHECK;
@@ -63,7 +64,7 @@ public class Board extends BaseEntity {
     private CheckRegister permitRegister;
 
     @Column
-    private String image;
+    private String images;
 
 
     //관계설정 유저에 관한 외래키 보유 주인테이블
@@ -84,6 +85,15 @@ public class Board extends BaseEntity {
     @OneToMany(mappedBy = "board", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ReportBoard> Reports = new ArrayList<>();
 
+    public List<String> getImageList() {
+        if (images == null || images.isEmpty()) {
+            return null;
+        }
+
+        String[] imageArray = images.substring(1, images.length() - 1).split(", ");
+        return new ArrayList<>(Arrays.asList(imageArray));
+    }
+
     @Builder
     public Board(String title, String content, boolean activeCheck, String image, int recommendCount, int viewCount, CheckRegister permitRegister ,User user,Music music) {
         this.title = title;
@@ -92,7 +102,7 @@ public class Board extends BaseEntity {
         this.viewCount = 0; // 기본값 설정
         this.activeCheck = activeCheck;
         this.permitRegister = NON_CHECK;
-        this.image = image;
+        this.images = image;
         this.user = user;
         this.music = music;
     }
@@ -114,7 +124,7 @@ public class Board extends BaseEntity {
         this.music = music;
         this.title = title;
         this.content = content;
-        this.image = image;
+        this.images = image;
         return this;
     }
     public void updateRegister(CheckRegister checkRegister) {

--- a/src/main/java/com/example/musing/board/entity/Board.java
+++ b/src/main/java/com/example/musing/board/entity/Board.java
@@ -2,6 +2,7 @@ package com.example.musing.board.entity;
 
 import com.example.musing.board.dto.PostDto;
 import com.example.musing.common.jpa.BaseEntity;
+import com.example.musing.exception.CustomException;
 import com.example.musing.music.entity.Music;
 import com.example.musing.reply.entity.Reply;
 import com.example.musing.report.entity.ReportBoard;
@@ -17,6 +18,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.example.musing.board.entity.CheckRegister.NON_CHECK;
+import static com.example.musing.exception.ErrorCode.NOT_FOUND_USER;
 
 @Getter // Lombok 어노테이션 : 클래스 내 모든 필드의 Getter 메소드 자동 생성
 @NoArgsConstructor// Lombok 어노테이션 : 기본 생성자 자동 추가
@@ -95,6 +97,26 @@ public class Board extends BaseEntity {
         this.music = music;
     }
 
+    public static Board of(User user, Music music, String title, String content, String images) {
+        return Board.builder()
+                .user(user)
+                .music(music)
+                .title(title)
+                .content(content)
+                .image(images)
+                .activeCheck(true)
+                .recommendCount(0)
+                .viewCount(0)
+                .build();
+    }
+
+    public Board updateBoard(Music music, String title, String content, String image) {
+        this.music = music;
+        this.title = title;
+        this.content = content;
+        this.image = image;
+        return this;
+    }
     public void updateRegister(CheckRegister checkRegister) {
         this.permitRegister = checkRegister;
     }

--- a/src/main/java/com/example/musing/board/service/BoardService.java
+++ b/src/main/java/com/example/musing/board/service/BoardService.java
@@ -29,7 +29,7 @@ public interface BoardService {
     // 글 삭제
     void deleteBoard(Long boardId);
     //글 수정
-     void updateBoard(UpdateBoardRequestDto request, List<String> deleteFileLinks, List<MultipartFile> newFiles);
+     void updateBoard(Long boardId, UpdateBoardRequestDto request, List<String> deleteFileLinks, List<MultipartFile> newFiles);
 
      DetailResponse selectDetail(long boardId);
 }

--- a/src/main/java/com/example/musing/board/service/BoardService.java
+++ b/src/main/java/com/example/musing/board/service/BoardService.java
@@ -29,7 +29,7 @@ public interface BoardService {
     // 글 삭제
     void deleteBoard(Long boardId);
     //글 수정
-     void updateBoard(UpdateBoardRequestDto request, List<MultipartFile> images);
+     void updateBoard(UpdateBoardRequestDto request, List<String> deleteFileLinks, List<MultipartFile> newFiles);
 
      DetailResponse selectDetail(long boardId);
 }

--- a/src/main/java/com/example/musing/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/example/musing/board/service/BoardServiceImpl.java
@@ -425,7 +425,6 @@ public class BoardServiceImpl implements BoardService {
         }
 
         // 조건에 맞는 3개 이하의 게시글 가져오기
-        List<Board> randomBoard = selectRandomBoards(boards, 3);
         BoardListResponseDto.RecommendBoardFirstDto firstPopUpDto = findBoardListPopUpFirst(boards);
 
         List<BoardListResponseDto.BoardRecapDto> boardPopUpDto = new ArrayList<>();
@@ -462,23 +461,6 @@ public class BoardServiceImpl implements BoardService {
     private List<Board> findBySpecBoard(Specification<Board> spec, PageRequest request) {
         Page<Board> boards = boardRepository.findAll(spec, request); //조건에 부합하는 게시글 전부가져오기
         return boards.getContent();
-    }
-
-    // 랜덤한 게시글을 가져오는 메서드
-    private List<Board> selectRandomBoards(List<Board> boards, int count) {
-        int effectiveCount = Math.min(count, boards.size());
-
-        Set<Integer> selectedIndices = new HashSet<>();
-        Random random = new Random();
-
-        while (selectedIndices.size() < effectiveCount) {
-            int randomIndex = random.nextInt(boards.size());
-            selectedIndices.add(randomIndex);
-        }
-
-        return selectedIndices.stream()
-                .map(boards::get)
-                .collect(Collectors.toList());
     }
 
     private BoardListResponseDto.RecommendBoardFirstDto findBoardListPopUpFirst(List<Board> boards) {

--- a/src/main/java/com/example/musing/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/example/musing/board/service/BoardServiceImpl.java
@@ -351,17 +351,15 @@ public class BoardServiceImpl implements BoardService {
         Music music = board.getMusic();
 
         // 첫 번째 Music의 Artist 정보 가져오기
-        String artistNames = (music != null && !music.getArtists().isEmpty())
-                ? music.getArtists().stream()
+        List<String> artistNames = music.getArtists().stream()
                 .map(am -> am.getArtist().getName())
-                .collect(Collectors.joining(", ")) // 여러 명일 경우 쉼표로 구분
-                : null;
+                .toList();
 
-        Long genreId = (music != null && !music.getArtists().isEmpty())
-                ? music.getArtists().get(0).getArtist().getId() // 첫 번째 아티스트의 장르 ID 사용
-                : null;
+        List<String> genreNames = music.getGenreMusics().stream()
+                .map(Genre_Music::getGenre)
+                .map(genre -> genre.getGenreName().getKey()).toList();
 
-        return DetailResponse.of(board, artistNames, extractHashtags(board.getContent()), genreId);
+        return DetailResponse.of(board, artistNames, extractHashtags(board.getContent()), genreNames);
     }
 
     private List<String> extractHashtags(String content) {
@@ -394,7 +392,7 @@ public class BoardServiceImpl implements BoardService {
         return board.getMusic().getGenreMusics().stream()
                 .map(Genre_Music::getGenre)
                 .map(GenreDto::toDto)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     //게시글의 음악에 포함된 분위기를 Dto로 담아 리스트로 반환
@@ -402,7 +400,7 @@ public class BoardServiceImpl implements BoardService {
         return board.getMusic().getMoodMusics().stream()
                 .map(Mood_Music::getMood)
                 .map(MoodDto::toDto)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     //게시글의 음악에 포함된 아티스트를 Dto로 담아 리스트로 반환
@@ -410,7 +408,7 @@ public class BoardServiceImpl implements BoardService {
         return board.getMusic().getArtists().stream()
                 .map(Artist_Music::getArtist)
                 .map(ArtistDto::toDto)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     // 음악 추천 게시판 상단

--- a/src/main/java/com/example/musing/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/example/musing/board/service/BoardServiceImpl.java
@@ -243,13 +243,13 @@ public class BoardServiceImpl implements BoardService {
 
     @Override
     @Transactional
-    public void updateBoard(UpdateBoardRequestDto request,
+    public void updateBoard(Long boardId, UpdateBoardRequestDto request,
                             List<String> deleteFileLinks, List<MultipartFile> newFiles) {
         // 유저명 저장
         String userId = SecurityContextHolder.getContext().getAuthentication().getName();
 
         // 기존 Board 객체를 찾기
-        Board board = boardRepository.findById(request.getBoardId())
+        Board board = boardRepository.findById(boardId)
                 .orElseThrow(() -> new CustomException(NOT_FOUND_BOARD));
 
 

--- a/src/main/java/com/example/musing/exception/ErrorCode.java
+++ b/src/main/java/com/example/musing/exception/ErrorCode.java
@@ -31,6 +31,7 @@ public enum ErrorCode {
     // 게시판 관련 예외처리
     NOT_FOUND_BOARD(NOT_FOUND, "해당 게시글을 불러올 수 없습니다."),
     NOT_FOUND_KEYWORD(NOT_FOUND, "해당 키워드로 검색할 수 없습니다."),
+    NOT_MATCHED_BOARD_AND_USER(CONFLICT, "해당 유저와 작성자가 일치하지 않습니다."),
     BAD_REQUEST_BOARD_PAGE(BAD_REQUEST, "해당 페이지는 존재하지 않습니다."),
 
 

--- a/src/main/java/com/example/musing/music/entity/Music.java
+++ b/src/main/java/com/example/musing/music/entity/Music.java
@@ -1,6 +1,7 @@
 package com.example.musing.music.entity;
 
 import com.example.musing.artist.entity.Artist_Music;
+import com.example.musing.board.dto.CreateBoardRequest;
 import com.example.musing.board.entity.Board;
 import com.example.musing.genre.entity.Genre_Music;
 import com.example.musing.hashtag.entity.HashTag;
@@ -70,6 +71,16 @@ public class Music {
         this.albumName = albumName;
         this.songLink = songLink;
         this.thumbNailLink = thumbNailLink;
+    }
+
+    public static Music of(CreateBoardRequest request) {
+        return Music.builder()
+                .name(request.getMusicTitle())
+                .playtime(request.getPlaytime())
+                .albumName(request.getAlbumName())
+                .songLink(request.getSongLink())
+                .thumbNailLink(request.getThumbNailLink())
+                .build();
     }
 
     // 해시태그 추가 메서드

--- a/src/main/java/com/example/musing/music/entity/Music.java
+++ b/src/main/java/com/example/musing/music/entity/Music.java
@@ -2,6 +2,7 @@ package com.example.musing.music.entity;
 
 import com.example.musing.artist.entity.Artist_Music;
 import com.example.musing.board.dto.CreateBoardRequest;
+import com.example.musing.board.dto.UpdateBoardRequestDto;
 import com.example.musing.board.entity.Board;
 import com.example.musing.genre.entity.Genre_Music;
 import com.example.musing.hashtag.entity.HashTag;
@@ -81,6 +82,15 @@ public class Music {
                 .songLink(request.getSongLink())
                 .thumbNailLink(request.getThumbNailLink())
                 .build();
+    }
+
+    public Music updateMusic(UpdateBoardRequestDto request) {
+        this.name = request.getMusicTitle();
+        this.playtime = request.getPlaytime();
+        this.songLink = request.getSongLink();
+        this.albumName = request.getAlbumName();
+        this.thumbNailLink = request.getThumbNailLink();
+        return this;
     }
 
     // 해시태그 추가 메서드


### PR DESCRIPTION
- 공통사항
  - 서비스 레이어에 사용된 빌더 패턴을 정적 팩토리 메서드 패턴에 맞춰 
  `@Builder`를 포함하던 해당 클래스에 선언 후 사용하도록 함
  
- 음악 추천 게시글 상세페이지 조회 수정사항
  - 누락된 데이터 createdAt, updatedAt, username 추가
  - artist와 genre의 데이터를 단일 String으로 받던 부분을 List로 수정

- 음악 추천 게시글 작성
   - S3 관련 코드 추가 및 공지사항 작성과 동일하게 이미지 처리 로직 사용

- 음악 추천 게시글 수정
   - S3 관련 코드 추가 및 공지사항 작성과 동일하게 이미지 처리 로직 사용
   - API를 직관적으로 나타내기 위해 Id가 주소에 포함되도록 변경