### PR TITLE
조회수 증가 및 게시글 좋아요 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ out/
 ### VS Code ###
 .vscode/
 src/main/resources/application.properties
+src/test/resources/application-test.properties

--- a/src/main/java/com/example/musing/board/controller/BoardController.java
+++ b/src/main/java/com/example/musing/board/controller/BoardController.java
@@ -1,9 +1,6 @@
 package com.example.musing.board.controller;
 
-import com.example.musing.board.dto.BoardListResponseDto;
-import com.example.musing.board.dto.CreateBoardRequest;
-import com.example.musing.board.dto.DetailResponse;
-import com.example.musing.board.dto.UpdateBoardRequestDto;
+import com.example.musing.board.dto.*;
 import com.example.musing.board.entity.Board;
 import com.example.musing.board.service.BoardService;
 import com.example.musing.common.dto.ResponseDto;
@@ -79,5 +76,11 @@ public class BoardController {
     public ResponseDto<DetailResponse> selectDetail(@RequestParam("boardId") Long boardId) {
         DetailResponse responseDto = boardService.selectDetail(boardId);
         return ResponseDto.of(responseDto, "글 조회에 성공했습니다.");
+    }
+
+    @PostMapping("recommend")
+    public ResponseDto<BoardRecommedDto> recommend(@RequestParam("boardId") Long boardId) {
+        BoardRecommedDto boardRecommedDto = boardService.toggleLike(boardId);
+        return ResponseDto.of(boardRecommedDto);
     }
 }

--- a/src/main/java/com/example/musing/board/dto/BoardRecommedDto.java
+++ b/src/main/java/com/example/musing/board/dto/BoardRecommedDto.java
@@ -1,0 +1,16 @@
+package com.example.musing.board.dto;
+
+import lombok.Builder;
+
+@Builder
+public record BoardRecommedDto(
+        int count,
+        boolean isLike)
+{
+    public static BoardRecommedDto of(int count, boolean isLike) {
+        return BoardRecommedDto.builder()
+                .count(count)
+                .isLike(isLike)
+                .build();
+    }
+}

--- a/src/main/java/com/example/musing/board/dto/DetailResponse.java
+++ b/src/main/java/com/example/musing/board/dto/DetailResponse.java
@@ -27,6 +27,7 @@ public record DetailResponse(
         String songLink,
         String thumbNailLink,
         int viewCount,
+        int recommendCount,
         String permitRegister) {
     public static DetailResponse of(Board board, List<String> artistsName, List<String> hashtags, List<String> genreName) {
         return DetailResponse.builder()
@@ -45,6 +46,7 @@ public record DetailResponse(
                 .songLink(board.getMusic().getSongLink())
                 .thumbNailLink(board.getMusic().getThumbNailLink())
                 .viewCount(board.getViewCount())
+                .recommendCount(board.getRecommendCount())
                 .permitRegister(board.getPermitRegister().name())
                 .build();
     }

--- a/src/main/java/com/example/musing/board/dto/DetailResponse.java
+++ b/src/main/java/com/example/musing/board/dto/DetailResponse.java
@@ -26,6 +26,7 @@ public record DetailResponse(
         String AlbumName,
         String songLink,
         String thumbNailLink,
+        int viewCount,
         String permitRegister) {
     public static DetailResponse of(Board board, List<String> artistsName, List<String> hashtags, List<String> genreName) {
         return DetailResponse.builder()
@@ -43,6 +44,7 @@ public record DetailResponse(
                 .AlbumName(board.getMusic().getAlbumName())
                 .songLink(board.getMusic().getSongLink())
                 .thumbNailLink(board.getMusic().getThumbNailLink())
+                .viewCount(board.getViewCount())
                 .permitRegister(board.getPermitRegister().name())
                 .build();
     }

--- a/src/main/java/com/example/musing/board/repository/BoardRepository.java
+++ b/src/main/java/com/example/musing/board/repository/BoardRepository.java
@@ -15,6 +15,9 @@ import java.util.Optional;
 
 
 public interface BoardRepository extends JpaRepository<Board, Long>, JpaSpecificationExecutor<Board> {
+    @Modifying
+    @Query("UPDATE Board b SET b.recommendCount = b.recommendCount + :delta WHERE b.id = :boardId")
+    int updateRecommendCount(@Param("boardId") Long boardId, @Param("delta") int delta);
 
     @Modifying
     @Query(value = "UPDATE Board b SET b.viewCount = b.viewCount + 1 WHERE b.id = :boardId")

--- a/src/main/java/com/example/musing/board/repository/BoardRepository.java
+++ b/src/main/java/com/example/musing/board/repository/BoardRepository.java
@@ -7,10 +7,7 @@ import com.example.musing.music.entity.Music;
 import com.example.musing.reply.entity.Reply;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.EntityGraph;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
-import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.*;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
@@ -18,6 +15,11 @@ import java.util.Optional;
 
 
 public interface BoardRepository extends JpaRepository<Board, Long>, JpaSpecificationExecutor<Board> {
+
+    @Modifying
+    @Query(value = "UPDATE Board b SET b.viewCount = b.viewCount + 1 WHERE b.id = :boardId")
+    void incrementBoardViewCount(@Param("boardId") Long boardId);
+
     @EntityGraph(attributePaths = {"music", "user"})
     @Query("SELECT b FROM Board b WHERE b.activeCheck = true AND b.id = :boardId")
     Optional<Board> findById(@Param("boardId") long boardId);

--- a/src/main/java/com/example/musing/board/service/BoardService.java
+++ b/src/main/java/com/example/musing/board/service/BoardService.java
@@ -2,6 +2,7 @@ package com.example.musing.board.service;
 
 import com.example.musing.board.dto.*;
 import com.example.musing.main.dto.RecommendBoardRight;
+import com.example.musing.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -29,7 +30,8 @@ public interface BoardService {
     // 글 삭제
     void deleteBoard(Long boardId);
     //글 수정
-     void updateBoard(Long boardId, UpdateBoardRequestDto request, List<String> deleteFileLinks, List<MultipartFile> newFiles);
+    void updateBoard(Long boardId, UpdateBoardRequestDto request, List<String> deleteFileLinks, List<MultipartFile> newFiles);
 
-     DetailResponse selectDetail(long boardId);
+    DetailResponse selectDetail(long boardId);
+    BoardRecommedDto toggleLike(long boardId);
 }

--- a/src/main/java/com/example/musing/like_music/entity/Like_Music.java
+++ b/src/main/java/com/example/musing/like_music/entity/Like_Music.java
@@ -3,13 +3,15 @@ package com.example.musing.like_music.entity;
 import com.example.musing.music.entity.Music;
 import com.example.musing.user.entity.User;
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
 @Entity
-@Table(name = "like_music")
+@Table(name = "like_music", uniqueConstraints =
+@UniqueConstraint(columnNames = {"user_id", "music_id"}))
 public class Like_Music {
 
     //유저가 좋아요를 눌렀을때에 관한 객체
@@ -27,4 +29,17 @@ public class Like_Music {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "musicid")
     private Music music;
+
+    @Builder
+    public Like_Music(User user, Music music) {
+        this.user = user;
+        this.music = music;
+    }
+
+    public static Like_Music of(User user, Music music) {
+        return Like_Music.builder()
+                .user(user)
+                .music(music)
+                .build();
+    }
 }

--- a/src/main/java/com/example/musing/like_music/repository/Like_MusicRepository.java
+++ b/src/main/java/com/example/musing/like_music/repository/Like_MusicRepository.java
@@ -1,14 +1,17 @@
 package com.example.musing.like_music.repository;
 
 import com.example.musing.like_music.entity.Like_Music;
+import com.example.musing.music.entity.Music;
 import com.example.musing.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface Like_MusicRepository extends JpaRepository<Like_Music, Long> {
+    Optional<Like_Music> findByUserAndMusic(User user, Music music);
     @Query("SELECT lm FROM Like_Music lm WHERE lm.user.id = :id ORDER BY lm.id DESC")
     List<Like_Music> findTop10ByUserOrderByIdDesc(@Param("id") String userId);
 

--- a/src/main/java/com/example/musing/like_music/service/Like_MusicService.java
+++ b/src/main/java/com/example/musing/like_music/service/Like_MusicService.java
@@ -1,0 +1,8 @@
+package com.example.musing.like_music.service;
+
+import com.example.musing.music.entity.Music;
+import com.example.musing.user.entity.User;
+
+public interface Like_MusicService {
+    boolean toggleRecommend(User user, Music music);
+}

--- a/src/main/java/com/example/musing/like_music/service/Like_MusicServiceImpl.java
+++ b/src/main/java/com/example/musing/like_music/service/Like_MusicServiceImpl.java
@@ -1,0 +1,50 @@
+package com.example.musing.like_music.service;
+
+import com.example.musing.like_music.entity.Like_Music;
+import com.example.musing.like_music.repository.Like_MusicRepository;
+import com.example.musing.music.entity.Music;
+import com.example.musing.user.entity.User;
+import com.example.musing.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.core.parameters.P;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class Like_MusicServiceImpl implements Like_MusicService {
+    private final Like_MusicRepository likeMusicRepository;
+
+    @Override
+    @Transactional(isolation = Isolation.READ_COMMITTED)
+    public boolean toggleRecommend(User user, Music music) {
+        try {
+            Optional<Like_Music> likeMusic = likeMusicRepository.findByUserAndMusic(user, music);
+            if (likeMusic.isEmpty()) {
+                likeMusic(user, music);
+                return true;
+            } else {
+                canceledLikeMusic(likeMusic.get());
+                return false;
+            }
+        } catch (DataIntegrityViolationException e) {
+            //유니크 제약조건 에러, 중복되는 데이터 생성을 막기위해 추가
+            return false;
+        }
+    }
+
+    private void likeMusic(User user, Music music) {
+        Like_Music likeMusic = Like_Music.of(user, music);
+        likeMusicRepository.save(likeMusic);
+    }
+
+    private void canceledLikeMusic(Like_Music likeMusic) {
+        likeMusicRepository.delete(likeMusic);
+    }
+}

--- a/src/test/java/com/example/musing/board/service/BoardServiceImplTest.java
+++ b/src/test/java/com/example/musing/board/service/BoardServiceImplTest.java
@@ -1,0 +1,109 @@
+package com.example.musing.board.service;
+
+import com.example.musing.board.entity.Board;
+import com.example.musing.board.repository.BoardRepository;
+import com.example.musing.music.entity.Music;
+import com.example.musing.music.repository.MusicRepository;
+import com.example.musing.user.entity.User;
+import com.example.musing.user.repository.UserRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+class BoardServiceImplTest {
+    /*@Autowired
+    private BoardRepository boardRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private MusicRepository musicRepository;
+
+    @Autowired
+    private BoardService boardService;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    private Board createBoard() {
+        return Board.builder()
+                .title("테스트 제목")
+                .content("테스트 내용")
+                .user(createUser())
+                .music(createMusic())
+                .activeCheck(true)
+                .viewCount(0)
+                .build();
+    }
+
+    private User createUser() {
+        User user = User.builder()
+                .id("구글 더미 아이디")
+                .username("더미")
+                .email("dummy@email.com")
+                .profile("프로필 사진 링크")
+                .build();
+        return userRepository.save(user);
+    }
+
+    private Music createMusic() {
+        Music music = Music.builder()
+                .name("제목")
+                .songLink("유튜브 링크")
+                .thumbNailLink("썸네일 링크")
+                .albumName(null)
+                .playtime("0:00")
+                .build();
+        return musicRepository.save(music);
+    }
+
+    @Transactional
+    @Test
+    @DisplayName("음악 추천 게시글에 100명의 동시 접속으로 조회 수의 동시성을 확인한다.")
+    void selectDetail() throws InterruptedException {
+        // given
+        final int THREAD_COUNT = 100;
+        Board board = boardRepository.save(createBoard());
+        entityManager.flush();
+        entityManager.clear();
+
+        ExecutorService executor = Executors.newFixedThreadPool(THREAD_COUNT);
+        CountDownLatch latch = new CountDownLatch(THREAD_COUNT);
+
+        // When
+        for (int i = 0; i < THREAD_COUNT; i++) {
+            executor.execute(() -> {
+                try {
+                    boardService.selectDetail(board.getId());
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        latch.await(); // 모든 스레드 작업 완료 대기
+
+        // Then
+        entityManager.clear(); // 영속성 컨텍스트 초기화
+        Board updated = boardRepository.findById(board.getId()).orElseThrow();
+        assertThat(updated.getViewCount())
+                .as("%d명 동시 접속 시 조회수 검증", THREAD_COUNT)
+                .isEqualTo(THREAD_COUNT);
+    }*/
+}


### PR DESCRIPTION
조회수 증가와 게시글 좋아요 기능을 추가했습니다.
동시성 문제는 트래픽이 우선 적을 부분으로 예상되는 것과 단순 카운트 변경이기에 경합이 적을것으로 예상하여
비관적 락의 한 형태인 Row-level locking을 사용으로 처리되도록 했습니다.

동시성 문제 확인을 위한 테스트 코드는 작성중입니다. 우선 주석처리 되어있습니다.
따로 테스트용 DB서버가 없어서 최소한으로만 할 예정입니다.


