### PR TITLE
스웨거 스키마 인식 안되던 버그 확인 및 의존성 주입 안되던 부분 수정

### DIFF
--- a/src/main/java/com/example/musing/admin/board/controller/AdminBoardController.java
+++ b/src/main/java/com/example/musing/admin/board/controller/AdminBoardController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/musing/admin/board")
 public class AdminBoardController {
-    private AdminBoardService adminBoardService;
+    private final AdminBoardService adminBoardService;
 
     @GetMapping("/removed")
     public ResponseDto<DetailResponse> getDeletedBoardDetail(@RequestParam Long boardId) {
@@ -20,35 +20,35 @@ public class AdminBoardController {
         return ResponseDto.of(responseDto);
     }
     @GetMapping("/list/removed")
-    public ResponseDto<Page<AdminBoardResponseDto.BoardListDto>> getDeletedBoards(
+    public ResponseDto<Page<AdminBoardResponseDto.AdminBoardListDto>> getDeletedBoards(
             @RequestParam(name = "page", defaultValue = "1") int page) {
-        Page<AdminBoardResponseDto.BoardListDto> responseList = adminBoardService.getDeletedPage(page);
+        Page<AdminBoardResponseDto.AdminBoardListDto> responseList = adminBoardService.getDeletedPage(page);
         return ResponseDto.of(responseList);
     }
 
     @GetMapping("/list/removed/search")
-    public ResponseDto<Page<AdminBoardResponseDto.BoardListDto>> getDeletedBoardsByKeyword(
+    public ResponseDto<Page<AdminBoardResponseDto.AdminBoardListDto>> getDeletedBoardsByKeyword(
             @RequestParam(name = "page", defaultValue = "1") int page,
             @RequestParam(name = "searchType") String searchType,
             @RequestParam(name = "keyword") String keyword) {
-        Page<AdminBoardResponseDto.BoardListDto> responseList =
+        Page<AdminBoardResponseDto.AdminBoardListDto> responseList =
                 adminBoardService.getDeletedSearchPage(page, searchType, keyword);
         return ResponseDto.of(responseList);
     }
 
     @GetMapping("/list")
-    public ResponseDto<Page<AdminBoardResponseDto.BoardListDto>> getBoards(
+    public ResponseDto<Page<AdminBoardResponseDto.AdminBoardListDto>> getBoards(
             @RequestParam(name = "page", defaultValue = "1") int page) {
-        Page<AdminBoardResponseDto.BoardListDto> responseList = adminBoardService.getRegisterPermitPage(page);
+        Page<AdminBoardResponseDto.AdminBoardListDto> responseList = adminBoardService.getRegisterPermitPage(page);
         return ResponseDto.of(responseList);
     }
 
     @GetMapping("/list/search")
-    public ResponseDto<Page<AdminBoardResponseDto.BoardListDto>> getBoardsByKeyword(
+    public ResponseDto<Page<AdminBoardResponseDto.AdminBoardListDto>> getBoardsByKeyword(
             @RequestParam(name = "page", defaultValue = "1") int page,
             @RequestParam(name = "searchType") String searchType,
             @RequestParam(name = "keyword") String keyword) {
-        Page<AdminBoardResponseDto.BoardListDto> responseList =
+        Page<AdminBoardResponseDto.AdminBoardListDto> responseList =
                 adminBoardService.getRegisterPermitSearchPage(page, searchType, keyword);
         return ResponseDto.of(responseList);
     }

--- a/src/main/java/com/example/musing/admin/board/dto/AdminBoardResponseDto.java
+++ b/src/main/java/com/example/musing/admin/board/dto/AdminBoardResponseDto.java
@@ -1,23 +1,19 @@
 package com.example.musing.admin.board.dto;
 
-import com.example.musing.artist.dto.ArtistDto;
 import com.example.musing.board.entity.Board;
-import com.example.musing.genre.dto.GenreDto;
-import com.example.musing.mood.dto.MoodDto;
-import com.example.musing.user.entity.User;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
 
 public class AdminBoardResponseDto {
     @Builder
-    public record BoardListDto(
+    public record AdminBoardListDto(
             String title,
             String username,
             LocalDateTime createdAt
     ) {
-        public static BoardListDto toDto(Board board) {
-            return BoardListDto.builder()
+        public static AdminBoardListDto toDto(Board board) {
+            return AdminBoardListDto.builder()
                     .title(board.getTitle())
                     .username(board.getUser().getUsername())
                     .createdAt(board.getCreatedAt())

--- a/src/main/java/com/example/musing/admin/board/service/AdminBoardService.java
+++ b/src/main/java/com/example/musing/admin/board/service/AdminBoardService.java
@@ -7,10 +7,10 @@ import org.springframework.data.domain.Page;
 public interface AdminBoardService {
 
     DetailResponse selectDetail(long boardId);
-    Page<AdminBoardResponseDto.BoardListDto> getRegisterPermitSearchPage(int page, String searchType, String keyword);
-    Page<AdminBoardResponseDto.BoardListDto> getDeletedSearchPage(int page, String searchType, String keyword);
-    Page<AdminBoardResponseDto.BoardListDto> getRegisterPermitPage(int page);
-    Page<AdminBoardResponseDto.BoardListDto> getDeletedPage(int page);
+    Page<AdminBoardResponseDto.AdminBoardListDto> getRegisterPermitSearchPage(int page, String searchType, String keyword);
+    Page<AdminBoardResponseDto.AdminBoardListDto> getDeletedSearchPage(int page, String searchType, String keyword);
+    Page<AdminBoardResponseDto.AdminBoardListDto> getRegisterPermitPage(int page);
+    Page<AdminBoardResponseDto.AdminBoardListDto> getDeletedPage(int page);
 
     void updateBoardStateNeedFix(long boardId);
     void updateBoardStatePermit(long boardId);

--- a/src/main/java/com/example/musing/admin/board/service/AdminBoardServiceImpl.java
+++ b/src/main/java/com/example/musing/admin/board/service/AdminBoardServiceImpl.java
@@ -2,15 +2,10 @@ package com.example.musing.admin.board.service;
 
 import com.example.musing.admin.board.dto.AdminBoardResponseDto;
 import com.example.musing.admin.board.repository.AdminBoardRepository;
-import com.example.musing.artist.dto.ArtistDto;
-import com.example.musing.artist.entity.Artist_Music;
 import com.example.musing.board.dto.DetailResponse;
 import com.example.musing.board.entity.Board;
 import com.example.musing.exception.CustomException;
-import com.example.musing.genre.dto.GenreDto;
 import com.example.musing.genre.entity.Genre_Music;
-import com.example.musing.mood.dto.MoodDto;
-import com.example.musing.mood.entity.Mood_Music;
 import com.example.musing.music.entity.Music;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -59,24 +54,24 @@ public class AdminBoardServiceImpl implements AdminBoardService {
         return DetailResponse.of(board, artistNames, extractHashtags(board.getContent()), genreNames);
     }
     @Override
-    public Page<AdminBoardResponseDto.BoardListDto> getRegisterPermitSearchPage(int page, String searchType,
-                                                                                 String keyword) {
+    public Page<AdminBoardResponseDto.AdminBoardListDto> getRegisterPermitSearchPage(int page, String searchType,
+                                                                                     String keyword) {
         return search(page, searchType, keyword, NON_CHECK_PERMIT);
     }
 
     @Override
-    public Page<AdminBoardResponseDto.BoardListDto> getDeletedSearchPage(int page, String searchType,
-                                                                                String keyword) {
+    public Page<AdminBoardResponseDto.AdminBoardListDto> getDeletedSearchPage(int page, String searchType,
+                                                                              String keyword) {
         return search(page, searchType, keyword, DELETED_PAGE);
     }
 
     @Override
-    public Page<AdminBoardResponseDto.BoardListDto> getRegisterPermitPage(int page) {
+    public Page<AdminBoardResponseDto.AdminBoardListDto> getRegisterPermitPage(int page) {
         return findBoardPage(page, NON_CHECK_PERMIT);
     }
 
     @Override
-    public Page<AdminBoardResponseDto.BoardListDto> getDeletedPage(int page) {
+    public Page<AdminBoardResponseDto.AdminBoardListDto> getDeletedPage(int page) {
         return findBoardPage(page, DELETED_PAGE);
     }
 
@@ -101,7 +96,7 @@ public class AdminBoardServiceImpl implements AdminBoardService {
                 .collect(Collectors.toList());
     }
 
-    private Page<AdminBoardResponseDto.BoardListDto> search(int page, String searchType, String keyword, String boardType) {
+    private Page<AdminBoardResponseDto.AdminBoardListDto> search(int page, String searchType, String keyword, String boardType) {
         if (page < 1) { // 잘못된 접근으로 throw할때 쿼리문 실행을 안하기 위해 나눠서 체크
             throw new CustomException(BAD_REQUEST_BOARD_PAGE);
         }
@@ -116,10 +111,10 @@ public class AdminBoardServiceImpl implements AdminBoardService {
             throw new CustomException(BAD_REQUEST_BOARD_PAGE);
         }
 
-        return boards.map(AdminBoardResponseDto.BoardListDto::toDto);
+        return boards.map(AdminBoardResponseDto.AdminBoardListDto::toDto);
     }
 
-    private Page<AdminBoardResponseDto.BoardListDto> findBoardPage(int page, String boardType) {
+    private Page<AdminBoardResponseDto.AdminBoardListDto> findBoardPage(int page, String boardType) {
         if (page < 1) { // 잘못된 접근으로 throw할때 쿼리문 실행을 안하기 위해 나눠서 체크
             throw new CustomException(BAD_REQUEST_BOARD_PAGE);
         }
@@ -132,7 +127,7 @@ public class AdminBoardServiceImpl implements AdminBoardService {
             throw new CustomException(BAD_REQUEST_BOARD_PAGE);
         }
 
-        return boards.map(AdminBoardResponseDto.BoardListDto::toDto);
+        return boards.map(AdminBoardResponseDto.AdminBoardListDto::toDto);
     }
 
     private Page<Board> findPage(String boardType, Pageable pageable) {


### PR DESCRIPTION
- 우선 겹치는 내부 클래스명을 Admin을 붙이는 것으로 우선 처리
> Dto 전송에서 비슷하지만 보내주는 데이터가 조금씩 다르던부분을 request와 response로 묶어서 내부클래스로 사용 중이였음.
> 
> 이러면서 내부 클래스명이 겹치는 부분은 스웨거가 인식을 못하고 다른걸로 참조하는 경우도 있음.
> 
> 예시로 AdminResponseClass.BoardDtoClass,  UserResponseClass.BoardDtoClass로 처음 클래스명이 다르지만 내부에 선언되어있는 클래스 이름이 겹치는 경우에만 이런걸로 확인
> 

- `final`누락으로 의존성 주입안되던 부분 수정

