### PR TITLE
회원탈퇴 기능 개선 및 게시글 조회 유저 정보 추가

### DIFF
--- a/src/main/java/com/example/musing/board/dto/DetailResponse.java
+++ b/src/main/java/com/example/musing/board/dto/DetailResponse.java
@@ -15,6 +15,7 @@ public record DetailResponse(
         String title,
         String musicTitle,
         String username,
+        String email,
         LocalDateTime createdAt,
         LocalDateTime updatedAt,
         List<String> artist,
@@ -34,6 +35,7 @@ public record DetailResponse(
                 .title(board.getTitle())
                 .musicTitle(board.getMusic().getName())
                 .username(board.getUser().getUsername())
+                .email(board.getUser().getEmail())
                 .createdAt(board.getCreatedAt())
                 .updatedAt(board.getUpdatedAt())
                 .artist(artistsName)

--- a/src/main/java/com/example/musing/user/controller/UserController.java
+++ b/src/main/java/com/example/musing/user/controller/UserController.java
@@ -31,7 +31,7 @@ public class UserController {
     private final MoodService moodService;
 
     @GetMapping("/withdraw")
-    public ResponseDto<String> deactivateUser(HttpServletResponse response) throws IOException, InterruptedException {
+    public ResponseDto<String> deactivateUser(HttpServletResponse response) {
         userService.withdraw(response);
         return ResponseDto.of("회원 탈퇴에 성공했습니다.");
     }

--- a/src/main/java/com/example/musing/user/event/UserEventListener.java
+++ b/src/main/java/com/example/musing/user/event/UserEventListener.java
@@ -1,0 +1,24 @@
+package com.example.musing.user.event;
+
+import com.example.musing.auth.oauth2.service.Oauth2ProviderTokenService;
+import com.example.musing.playlist.event.DeleteVideoEvent;
+import com.example.musing.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.io.IOException;
+
+
+@RequiredArgsConstructor
+@Component
+public class UserEventListener {
+    private final Oauth2ProviderTokenService oauth2ProviderTokenService;
+
+    @TransactionalEventListener
+    @Async
+    public void disconnectThirdPartyService(String userId) throws IOException, InterruptedException {
+        oauth2ProviderTokenService.disconnectThirdPartyService(userId);
+    }
+}

--- a/src/main/java/com/example/musing/user/service/UserService.java
+++ b/src/main/java/com/example/musing/user/service/UserService.java
@@ -14,7 +14,7 @@ import java.io.IOException;
 import java.util.List;
 
 public interface UserService {
-    void withdraw(HttpServletResponse response) throws IOException, InterruptedException;
+    void withdraw(HttpServletResponse response);
     String checkInputTags(String userId);
     User findById(String userId);
     void saveGenres(String userid, List<Long> genres);


### PR DESCRIPTION
- 회원탈퇴 과정에서 DB작업과 서드파티 연동 해제와 관련한 API를 
Spring event를 사용하여 트랜잭션을 분리해 Hikari CP 반환이 빨라지도록 개선

- 현재 로그인한 유저와 게시글 작성자가 동일한지 구분하기 위해 이메일을 추가로 제공하도록 수정